### PR TITLE
static_assert that casting of pointer is safe

### DIFF
--- a/src/scheme.c
+++ b/src/scheme.c
@@ -17,6 +17,8 @@
     \ingroup gerbv
 */
 
+#include <assert.h>
+
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -584,6 +586,9 @@ static int alloc_cellseg(scheme *sc, int n) {
 	  i = ++sc->last_cell_seg ;
 	  sc->alloc_seg[i] = cp;
 	  /* adjust in TYPE_BITS-bit boundary */
+	  /* Check that the casting below is safe. */
+	  static_assert(sizeof(size_t) == sizeof(cp),
+	                "Can't cast pointer to size_t.");
 	  if((size_t)cp%adj!=0) {
 	    cp=(char*)(adj*((size_t)cp/adj+1));
 	  }


### PR DESCRIPTION
static_assert runs whether or not the function is called and emits no assembly so there is no performance impact.  This change ensures that a mismatch of types will be caught at compile time.

https://en.cppreference.com/w/c/language/_Static_assert